### PR TITLE
Convert GitHub/New_release_pipeline to GitHub Actions

### DIFF
--- a/.github/workflows/new_release_pipeline.yml
+++ b/.github/workflows/new_release_pipeline.yml
@@ -1,0 +1,12 @@
+name: GitHub/New_release_pipeline
+on:
+  workflow_dispatch:
+jobs:
+  Production:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: "${{ github.ref }}"
+      cancel-in-progress: false
+    if: github.event_type != 'pull_request'
+    steps:
+#     # 497d490f-eea7-4f2b-ab94-48d9c1acdcb1@4: unsupported application type ($(Parameters.WebAppKind))


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/jpfedevopsdemo/GitHub/_release?_a=releases&definitionId=1) :tada: